### PR TITLE
Add basic FriendBet frontend and Supabase schema

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,0 +1,162 @@
+const supabaseUrl = 'https://YOUR_PROJECT.supabase.co';
+const supabaseKey = 'YOUR_PUBLIC_ANON_KEY';
+const client = supabase.createClient(supabaseUrl, supabaseKey);
+
+let currentGroup = null;
+let currentMember = null;
+
+async function createGroup() {
+  const hostName = document.getElementById('host-name').value.trim();
+  const groupName = document.getElementById('group-name').value.trim();
+  if (!hostName || !groupName) return;
+  const code = Math.random().toString(36).substring(2, 8);
+  const { data: group, error } = await client
+    .from('groups')
+    .insert({ name: groupName, host_name: hostName, join_code: code })
+    .select()
+    .single();
+  if (error) {
+    console.error(error);
+    return;
+  }
+  const { data: member } = await client
+    .from('members')
+    .insert({ group_id: group.id, name: hostName })
+    .select()
+    .single();
+  currentGroup = group;
+  currentMember = member;
+  localStorage.setItem('groupId', group.id);
+  localStorage.setItem('memberId', member.id);
+  document.getElementById('create-group-result').textContent = `Group code: ${code}`;
+  showApp();
+}
+
+async function joinGroup() {
+  const name = document.getElementById('join-name').value.trim();
+  const code = document.getElementById('join-code').value.trim();
+  if (!name || !code) return;
+  const { data: group, error } = await client
+    .from('groups')
+    .select()
+    .eq('join_code', code)
+    .single();
+  if (error || !group) {
+    alert('Group not found');
+    return;
+  }
+  const { data: member } = await client
+    .from('members')
+    .insert({ group_id: group.id, name })
+    .select()
+    .single();
+  currentGroup = group;
+  currentMember = member;
+  localStorage.setItem('groupId', group.id);
+  localStorage.setItem('memberId', member.id);
+  showApp();
+}
+
+function showApp() {
+  document.getElementById('auth').classList.add('hidden');
+  document.getElementById('app').classList.remove('hidden');
+  document.getElementById('group-title').textContent = `${currentGroup.name} (code: ${currentGroup.join_code})`;
+  loadMembers();
+  loadBets();
+}
+
+async function loadMembers() {
+  const { data } = await client
+    .from('members')
+    .select()
+    .eq('group_id', currentGroup.id);
+  const list = document.getElementById('block-members');
+  const membersDiv = document.getElementById('members');
+  list.innerHTML = '';
+  membersDiv.innerHTML = `<h3>Members</h3><ul>${data
+    .map((m) => `<li>${m.name} (${m.points} pts)</li>`)
+    .join('')}</ul>`;
+  data.forEach((m) => {
+    if (m.id === currentMember.id) return;
+    const option = document.createElement('option');
+    option.value = m.id;
+    option.textContent = m.name;
+    list.appendChild(option);
+  });
+}
+
+async function loadBets() {
+  const { data: blocked } = await client
+    .from('bet_blocks')
+    .select('bet_id')
+    .eq('member_id', currentMember.id);
+  const blockedIds = blocked.map((b) => b.bet_id);
+  const { data: bets } = await client
+    .from('bets')
+    .select()
+    .eq('group_id', currentGroup.id);
+  const visible = bets.filter((b) => !blockedIds.includes(b.id));
+  const list = document.getElementById('bet-list');
+  list.innerHTML = '';
+  visible.forEach((b) => {
+    const li = document.createElement('li');
+    li.textContent = `${b.description} - by ${b.creator_name}`;
+    list.appendChild(li);
+  });
+}
+
+async function createBet() {
+  const desc = document.getElementById('bet-desc').value.trim();
+  const select = document.getElementById('block-members');
+  if (!desc) return;
+  const { data: bet } = await client
+    .from('bets')
+    .insert({
+      group_id: currentGroup.id,
+      creator_id: currentMember.id,
+      creator_name: currentMember.name,
+      description: desc,
+    })
+    .select()
+    .single();
+  const blocks = Array.from(select.selectedOptions).map((opt) => ({
+    bet_id: bet.id,
+    member_id: opt.value,
+  }));
+  if (blocks.length) {
+    await client.from('bet_blocks').insert(blocks);
+  }
+  document.getElementById('bet-desc').value = '';
+  select.selectedIndex = -1;
+  loadBets();
+}
+
+// Event listeners
+
+document
+  .getElementById('create-group-btn')
+  .addEventListener('click', createGroup);
+document
+  .getElementById('join-group-btn')
+  .addEventListener('click', joinGroup);
+document
+  .getElementById('create-bet-btn')
+  .addEventListener('click', createBet);
+
+// Resume session if stored
+(function init() {
+  const groupId = localStorage.getItem('groupId');
+  const memberId = localStorage.getItem('memberId');
+  if (groupId && memberId) {
+    Promise.all([
+      client.from('groups').select().eq('id', groupId).single(),
+      client.from('members').select().eq('id', memberId).single(),
+    ]).then(([g, m]) => {
+      if (g.data && m.data) {
+        currentGroup = g.data;
+        currentMember = m.data;
+        showApp();
+      }
+    });
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>FriendBet</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+</head>
+<body>
+  <div id="auth">
+    <h1>FriendBet</h1>
+    <section id="create-group">
+      <h2>Create Group</h2>
+      <input id="host-name" placeholder="Your name" />
+      <input id="group-name" placeholder="Group name" />
+      <button id="create-group-btn">Create</button>
+      <p id="create-group-result"></p>
+    </section>
+    <section id="join-group">
+      <h2>Join Group</h2>
+      <input id="join-name" placeholder="Your name" />
+      <input id="join-code" placeholder="Join code" />
+      <button id="join-group-btn">Join</button>
+    </section>
+  </div>
+
+  <div id="app" class="hidden">
+    <h2 id="group-title"></h2>
+    <div id="members"></div>
+    <section id="create-bet">
+      <h3>Create Bet</h3>
+      <input id="bet-desc" placeholder="Bet description" />
+      <label for="block-members">Hide from:</label>
+      <select id="block-members" multiple></select>
+      <button id="create-bet-btn">Create Bet</button>
+    </section>
+    <section id="bets">
+      <h3>Bets</h3>
+      <ul id="bet-list"></ul>
+    </section>
+  </div>
+
+  <script src="code.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+.hidden {
+  display: none;
+}
+
+input,
+button,
+select {
+  margin: 5px 0;
+  padding: 5px;
+}
+
+section {
+  margin-bottom: 20px;
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,0 +1,47 @@
+-- Groups that hold members and bets
+create table groups (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  host_name text not null,
+  join_code text not null unique,
+  created_at timestamptz default now()
+);
+
+-- Members belonging to a group
+create table members (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid references groups(id) on delete cascade,
+  name text not null,
+  points int default 100,
+  created_at timestamptz default now()
+);
+
+-- Bets created in a group
+create table bets (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid references groups(id) on delete cascade,
+  creator_id uuid references members(id) on delete set null,
+  creator_name text,
+  description text not null,
+  created_at timestamptz default now()
+);
+
+-- Users blocked from seeing a bet
+create table bet_blocks (
+  bet_id uuid references bets(id) on delete cascade,
+  member_id uuid references members(id) on delete cascade,
+  primary key (bet_id, member_id)
+);
+
+-- open access policies (no auth)
+alter table groups enable row level security;
+create policy "Allow all" on groups for all using (true);
+
+alter table members enable row level security;
+create policy "Allow all" on members for all using (true);
+
+alter table bets enable row level security;
+create policy "Allow all" on bets for all using (true);
+
+alter table bet_blocks enable row level security;
+create policy "Allow all" on bet_blocks for all using (true);


### PR DESCRIPTION
## Summary
- create simple webpage for creating/joining groups, members, and bets
- add Supabase client logic with local storage session and bet visibility
- include SQL commands to set up Supabase tables and open policies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be566055848320be2fe3b74a8a5692