### PR TITLE
Add basic FriendBet prototype and Supabase schema

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,0 +1,150 @@
+// Replace with your Supabase project credentials
+const SUPABASE_URL = 'https://YOUR-PROJECT.supabase.co';
+const SUPABASE_ANON_KEY = 'YOUR_ANON_KEY';
+
+const db = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+async function createGroup() {
+  const hostName = document.getElementById('host-name').value.trim();
+  const groupName = document.getElementById('group-name').value.trim();
+  if (!hostName || !groupName) {
+    alert('Enter a name and group');
+    return;
+  }
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase();
+  const { data: group, error } = await db.from('groups').insert({ name: groupName, code, host_name: hostName }).select().single();
+  if (error) {
+    alert(error.message);
+    return;
+  }
+  const { data: user, error: userError } = await db.from('users').insert({ group_id: group.id, name: hostName }).select().single();
+  if (userError) {
+    alert(userError.message);
+    return;
+  }
+  localStorage.setItem('group', JSON.stringify(group));
+  localStorage.setItem('user', JSON.stringify(user));
+  init();
+  alert(`Group created! Share this code: ${code}`);
+}
+
+async function joinGroup() {
+  const joinName = document.getElementById('join-name').value.trim();
+  const joinCode = document.getElementById('join-code').value.trim().toUpperCase();
+  if (!joinName || !joinCode) {
+    alert('Enter a name and code');
+    return;
+  }
+  const { data: group, error } = await db.from('groups').select().eq('code', joinCode).single();
+  if (error || !group) {
+    alert('Group not found');
+    return;
+  }
+  const { data: user, error: userError } = await db.from('users').insert({ group_id: group.id, name: joinName }).select().single();
+  if (userError) {
+    alert(userError.message);
+    return;
+  }
+  localStorage.setItem('group', JSON.stringify(group));
+  localStorage.setItem('user', JSON.stringify(user));
+  init();
+}
+
+async function init() {
+  const group = JSON.parse(localStorage.getItem('group'));
+  const user = JSON.parse(localStorage.getItem('user'));
+  if (!group || !user) return;
+  document.getElementById('auth').classList.add('hidden');
+  document.getElementById('app').classList.remove('hidden');
+  document.getElementById('group-header').textContent = `${group.name} (code: ${group.code})`;
+  const { data: freshUser } = await db.from('users').select().eq('id', user.id).single();
+  localStorage.setItem('user', JSON.stringify(freshUser));
+  document.getElementById('points').textContent = freshUser.points;
+  loadBets();
+}
+
+async function loadBets() {
+  const group = JSON.parse(localStorage.getItem('group'));
+  const user = JSON.parse(localStorage.getItem('user'));
+  const { data: bets } = await db.from('bets').select('*').eq('group_id', group.id).order('created_at', { ascending: false });
+  const list = document.getElementById('bets-list');
+  list.innerHTML = '';
+  bets.filter(b => !(b.hidden_from && b.hidden_from.includes(user.id))).forEach(bet => {
+    const li = document.createElement('li');
+    li.innerHTML = `
+      <p>${bet.question}</p>
+      <form data-bet="${bet.id}">
+        <label><input type="radio" name="choice-${bet.id}" value="yes" checked>Yes</label>
+        <label><input type="radio" name="choice-${bet.id}" value="no">No</label>
+        <input type="number" min="1" placeholder="Points" required />
+        <button>Bet</button>
+      </form>
+    `;
+    list.appendChild(li);
+    const form = li.querySelector('form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const amount = parseInt(form.querySelector('input[type="number"]').value, 10);
+      if (!amount) return;
+      const choice = form.querySelector(`input[name="choice-${bet.id}"]:checked`).value;
+      await placeBet(bet.id, choice, amount);
+      form.reset();
+    });
+  });
+}
+
+async function createBet() {
+  const group = JSON.parse(localStorage.getItem('group'));
+  const user = JSON.parse(localStorage.getItem('user'));
+  const question = document.getElementById('bet-question').value.trim();
+  const exclude = document.getElementById('bet-exclude').value.trim();
+  if (!question) {
+    alert('Enter a question');
+    return;
+  }
+  const hidden_from = exclude ? exclude.split(',').map(s => s.trim()).filter(Boolean) : [];
+  const { error } = await db.from('bets').insert({
+    group_id: group.id,
+    creator_id: user.id,
+    question,
+    hidden_from
+  });
+  if (error) {
+    alert(error.message);
+    return;
+  }
+  document.getElementById('bet-question').value = '';
+  document.getElementById('bet-exclude').value = '';
+  loadBets();
+}
+
+async function placeBet(betId, choice, amount) {
+  const user = JSON.parse(localStorage.getItem('user'));
+  if (user.points < amount) {
+    alert('Not enough points');
+    return;
+  }
+  const { error } = await db.from('wagers').insert({ bet_id: betId, user_id: user.id, choice, amount });
+  if (error) {
+    alert(error.message);
+    return;
+  }
+  await db.from('users').update({ points: user.points - amount }).eq('id', user.id);
+  user.points -= amount;
+  localStorage.setItem('user', JSON.stringify(user));
+  document.getElementById('points').textContent = user.points;
+}
+
+// Event listeners
+if (document.getElementById('create-group')) {
+  document.getElementById('create-group').addEventListener('click', createGroup);
+}
+if (document.getElementById('join-group')) {
+  document.getElementById('join-group').addEventListener('click', joinGroup);
+}
+if (document.getElementById('create-bet')) {
+  document.getElementById('create-bet').addEventListener('click', createBet);
+}
+
+// Auto-init if stored
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>FriendBet</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+</head>
+<body>
+  <h1>FriendBet</h1>
+
+  <div id="auth">
+    <h2>Create Group</h2>
+    <input id="host-name" placeholder="Your name" />
+    <input id="group-name" placeholder="Group name" />
+    <button id="create-group">Create</button>
+
+    <h2>Join Group</h2>
+    <input id="join-name" placeholder="Your name" />
+    <input id="join-code" placeholder="Group code" />
+    <button id="join-group">Join</button>
+  </div>
+
+  <div id="app" class="hidden">
+    <h2 id="group-header"></h2>
+    <p>Your points: <span id="points"></span></p>
+
+    <section id="create-bet-section">
+      <h3>Create Bet</h3>
+      <input id="bet-question" placeholder="Bet question" />
+      <input id="bet-exclude" placeholder="Exclude user IDs (comma separated)" />
+      <button id="create-bet">Create Bet</button>
+    </section>
+
+    <section id="bets-section">
+      <h3>Bets</h3>
+      <ul id="bets-list"></ul>
+    </section>
+  </div>
+
+  <script src="code.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+input {
+  display: block;
+  margin: 5px 0;
+  padding: 8px;
+  width: 100%;
+}
+
+button {
+  padding: 8px 12px;
+  margin: 5px 0;
+}
+
+.hidden {
+  display: none;
+}
+
+#bets-list li {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,0 +1,38 @@
+-- Enable UUID generation
+create extension if not exists "pgcrypto";
+
+create table groups (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  code text unique not null,
+  host_name text not null,
+  created_at timestamp with time zone default now()
+);
+
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid references groups(id) on delete cascade,
+  name text not null,
+  points integer not null default 100,
+  created_at timestamp with time zone default now()
+);
+
+create table bets (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid references groups(id) on delete cascade,
+  creator_id uuid references users(id) on delete set null,
+  question text not null,
+  hidden_from uuid[] default '{}',
+  created_at timestamp with time zone default now(),
+  resolved boolean default false,
+  outcome text
+);
+
+create table wagers (
+  id uuid primary key default gen_random_uuid(),
+  bet_id uuid references bets(id) on delete cascade,
+  user_id uuid references users(id) on delete cascade,
+  choice text not null,
+  amount integer not null,
+  created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- Add index page with forms to create or join a group and manage bets.
- Implement Supabase-powered logic for groups, users, bets, and wagers.
- Provide SQL commands to create Supabase tables for groups, users, bets, and wagers.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be566055848320be2fe3b74a8a5692