### PR TITLE
Add FriendBet prototype, Supabase schema, and dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,131 @@
+import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
+
+const SUPABASE_URL = "YOUR_SUPABASE_URL";
+const SUPABASE_ANON_KEY = "YOUR_SUPABASE_ANON_KEY";
+
+if (SUPABASE_URL.includes("YOUR_SUPABASE_URL")) {
+  alert(
+    "Replace SUPABASE_URL and SUPABASE_ANON_KEY with your Supabase credentials.",
+  );
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+let currentGroup = null;
+let currentMember = null;
+
+document
+  .getElementById("create-group-form")
+  .addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const name = form.groupName.value.trim();
+    const startPoints = parseInt(form.startPoints.value, 10) || 100;
+    const memberName = form.memberName.value.trim();
+    const { data: group, error } = await supabase
+      .from("groups")
+      .insert({ name, start_points: startPoints })
+      .select()
+      .single();
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    currentGroup = group;
+    const { data: member, error: memberError } = await supabase
+      .from("members")
+      .insert({ group_id: group.id, name: memberName, points: startPoints })
+      .select()
+      .single();
+    if (memberError) {
+      alert(memberError.message);
+      return;
+    }
+    currentMember = member;
+    document.getElementById("group-code-display").textContent =
+      `Share this join code: ${group.join_code}`;
+    form.reset();
+  });
+
+document
+  .getElementById("join-group-form")
+  .addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const joinCode = form.joinCode.value.trim().toUpperCase();
+    const memberName = form.memberName.value.trim();
+    const { data: group, error } = await supabase
+      .from("groups")
+      .select()
+      .eq("join_code", joinCode)
+      .single();
+    if (error) {
+      alert("Group not found");
+      return;
+    }
+    currentGroup = group;
+    const { data: member, error: memberError } = await supabase
+      .from("members")
+      .insert({
+        group_id: group.id,
+        name: memberName,
+        points: group.start_points,
+      })
+      .select()
+      .single();
+    if (memberError) {
+      alert(memberError.message);
+      return;
+    }
+    currentMember = member;
+    form.reset();
+  });
+
+document
+  .getElementById("create-bet-form")
+  .addEventListener("submit", async (e) => {
+    e.preventDefault();
+    if (!currentGroup || !currentMember) {
+      alert("Join a group first");
+      return;
+    }
+    const form = e.target;
+    const description = form.description.value.trim();
+    const optionA = form.optionA.value.trim();
+    const optionB = form.optionB.value.trim();
+    const exclusionsRaw = form.exclusions.value.trim();
+    const { data: bet, error } = await supabase
+      .from("bets")
+      .insert({
+        group_id: currentGroup.id,
+        creator_member_id: currentMember.id,
+        description,
+        option_a: optionA,
+        option_b: optionB,
+      })
+      .select()
+      .single();
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    if (exclusionsRaw) {
+      const names = exclusionsRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (names.length) {
+        const { data: members } = await supabase
+          .from("members")
+          .select("id")
+          .eq("group_id", currentGroup.id)
+          .in("name", names);
+        for (const m of members || []) {
+          await supabase
+            .from("bet_exclusions")
+            .insert({ bet_id: bet.id, member_id: m.id });
+        }
+      }
+    }
+    form.reset();
+  });

--- a/index.html
+++ b/index.html
@@ -10,29 +10,34 @@
 
     <section id="create-group">
       <h2>Create Group</h2>
-      <form>
+      <form id="create-group-form">
         <label>
           Group Name
-          <input type="text" name="groupName" />
+          <input type="text" name="groupName" required />
         </label>
         <label>
-          Join Code
-          <input type="text" name="joinCode" />
+          Start Points
+          <input type="number" name="startPoints" value="100" />
+        </label>
+        <label>
+          Your Name
+          <input type="text" name="memberName" required />
         </label>
         <button type="submit">Create Group</button>
       </form>
+      <p id="group-code-display"></p>
     </section>
 
     <section id="join-group">
       <h2>Join Group</h2>
-      <form>
+      <form id="join-group-form">
         <label>
           Join Code
-          <input type="text" name="joinCode" />
+          <input type="text" name="joinCode" required />
         </label>
         <label>
           Your Name
-          <input type="text" name="memberName" />
+          <input type="text" name="memberName" required />
         </label>
         <button type="submit">Join Group</button>
       </form>
@@ -40,18 +45,18 @@
 
     <section id="create-bet">
       <h2>Create Bet</h2>
-      <form>
+      <form id="create-bet-form">
         <label>
           Description
-          <input type="text" name="description" />
+          <input type="text" name="description" required />
         </label>
         <label>
           Option A
-          <input type="text" name="optionA" />
+          <input type="text" name="optionA" required />
         </label>
         <label>
           Option B
-          <input type="text" name="optionB" />
+          <input type="text" name="optionB" required />
         </label>
         <label>
           Exclude Members (comma separated)
@@ -60,5 +65,6 @@
         <button type="submit">Create Bet</button>
       </form>
     </section>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>FriendBet</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>FriendBet</h1>
+
+    <section id="create-group">
+      <h2>Create Group</h2>
+      <form>
+        <label>
+          Group Name
+          <input type="text" name="groupName" />
+        </label>
+        <label>
+          Join Code
+          <input type="text" name="joinCode" />
+        </label>
+        <button type="submit">Create Group</button>
+      </form>
+    </section>
+
+    <section id="join-group">
+      <h2>Join Group</h2>
+      <form>
+        <label>
+          Join Code
+          <input type="text" name="joinCode" />
+        </label>
+        <label>
+          Your Name
+          <input type="text" name="memberName" />
+        </label>
+        <button type="submit">Join Group</button>
+      </form>
+    </section>
+
+    <section id="create-bet">
+      <h2>Create Bet</h2>
+      <form>
+        <label>
+          Description
+          <input type="text" name="description" />
+        </label>
+        <label>
+          Option A
+          <input type="text" name="optionA" />
+        </label>
+        <label>
+          Option B
+          <input type="text" name="optionB" />
+        </label>
+        <label>
+          Exclude Members (comma separated)
+          <input type="text" name="exclusions" />
+        </label>
+        <button type="submit">Create Bet</button>
+      </form>
+    </section>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,23 @@
+body {
+  background: #111;
+  color: #eee;
+  font-family: sans-serif;
+  margin: 2rem;
+}
+
+label {
+  display: block;
+  margin: 0.5rem 0;
+}
+
+input,
+button {
+  background: #222;
+  color: #eee;
+  border: 1px solid #444;
+  padding: 0.5rem;
+}
+
+button {
+  cursor: pointer;
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,0 +1,44 @@
+-- Enable UUID extension
+create extension if not exists "uuid-ossp";
+
+create table groups (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  join_code text unique not null,
+  start_points integer not null default 100,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table members (
+  id uuid primary key default uuid_generate_v4(),
+  group_id uuid references groups(id) on delete cascade,
+  name text not null,
+  points integer not null,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table bets (
+  id uuid primary key default uuid_generate_v4(),
+  group_id uuid references groups(id) on delete cascade,
+  creator_member_id uuid references members(id) on delete set null,
+  description text not null,
+  option_a text not null,
+  option_b text not null,
+  status text not null default 'open',
+  winning_option text,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table bet_exclusions (
+  bet_id uuid references bets(id) on delete cascade,
+  member_id uuid references members(id) on delete cascade,
+  primary key (bet_id, member_id)
+);
+
+create table wagers (
+  bet_id uuid references bets(id) on delete cascade,
+  member_id uuid references members(id) on delete cascade,
+  option text not null,
+  amount integer not null,
+  primary key (bet_id, member_id)
+);

--- a/supabase.sql
+++ b/supabase.sql
@@ -4,7 +4,7 @@ create extension if not exists "uuid-ossp";
 create table groups (
   id uuid primary key default uuid_generate_v4(),
   name text not null,
-  join_code text unique not null,
+  join_code text unique not null default upper(left(replace(uuid_generate_v4()::text, '-', ''), 6)),
   start_points integer not null default 100,
   created_at timestamp with time zone default timezone('utc'::text, now())
 );


### PR DESCRIPTION
## Summary
- Reset site to minimal HTML forms for creating groups, joining groups, and drafting bets
- Apply lightweight dark theme styling
- Provide Supabase SQL schema in `supabase.sql`

## Testing
- `npx prettier --check index.html style.css`
- `npx prettier --check supabase.sql --parser sql` *(fails: Couldn't resolve parser "sql")*


------
https://chatgpt.com/codex/tasks/task_e_68be566055848320be2fe3b74a8a5692