### PR TITLE
Add group pages with admin controls and Supabase schema commands

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,229 @@
+import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
+
+const SUPABASE_URL = "YOUR_SUPABASE_URL";
+const SUPABASE_ANON_KEY = "YOUR_SUPABASE_ANON_KEY";
+
+if (SUPABASE_URL.includes("YOUR_SUPABASE_URL")) {
+  alert(
+    "Replace SUPABASE_URL and SUPABASE_ANON_KEY with your Supabase credentials.",
+  );
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+const createGroupForm = document.getElementById("create-group-form");
+const joinGroupForm = document.getElementById("join-group-form");
+const createBetForm = document.getElementById("create-bet-form");
+
+if (createGroupForm) {
+  createGroupForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const name = form.groupName.value.trim();
+    const startPoints = parseInt(form.startPoints.value, 10) || 100;
+    const memberName = form.memberName.value.trim();
+    const { data: group, error } = await supabase
+      .from("groups")
+      .insert({ name, start_points: startPoints })
+      .select()
+      .single();
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    const { data: member, error: memberError } = await supabase
+      .from("members")
+      .insert({
+        group_id: group.id,
+        name: memberName,
+        points: startPoints,
+        is_admin: true,
+      })
+      .select()
+      .single();
+    if (memberError) {
+      alert(memberError.message);
+      return;
+    }
+    localStorage.setItem("groupId", group.id);
+    localStorage.setItem("memberId", member.id);
+    localStorage.setItem("isAdmin", "true");
+    window.location.href = "group.html";
+  });
+}
+
+if (joinGroupForm) {
+  joinGroupForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const joinCode = form.joinCode.value.trim().toUpperCase();
+    const memberName = form.memberName.value.trim();
+    const { data: group, error } = await supabase
+      .from("groups")
+      .select()
+      .eq("join_code", joinCode)
+      .single();
+    if (error) {
+      alert("Group not found");
+      return;
+    }
+    const { data: member, error: memberError } = await supabase
+      .from("members")
+      .insert({
+        group_id: group.id,
+        name: memberName,
+        points: group.start_points,
+      })
+      .select()
+      .single();
+    if (memberError) {
+      alert(memberError.message);
+      return;
+    }
+    localStorage.setItem("groupId", group.id);
+    localStorage.setItem("memberId", member.id);
+    localStorage.setItem("isAdmin", "false");
+    window.location.href = "group.html";
+  });
+}
+
+async function loadGroupPage() {
+  const groupId = localStorage.getItem("groupId");
+  const memberId = localStorage.getItem("memberId");
+  const isAdmin = localStorage.getItem("isAdmin") === "true";
+  if (!groupId || !memberId) {
+    window.location.href = "index.html";
+    return;
+  }
+  const { data: group, error } = await supabase
+    .from("groups")
+    .select()
+    .eq("id", groupId)
+    .single();
+  if (error) {
+    alert(error.message);
+    return;
+  }
+  document.getElementById("group-name").textContent = group.name;
+  document.getElementById("group-code").textContent = group.join_code;
+  if (isAdmin) {
+    document
+      .querySelectorAll(".admin-only")
+      .forEach((el) => el.classList.remove("hidden"));
+    document.getElementById("group-name-input").value = group.name;
+  }
+  await refreshMembers();
+}
+
+async function refreshMembers() {
+  const groupId = localStorage.getItem("groupId");
+  const memberId = localStorage.getItem("memberId");
+  const isAdmin = localStorage.getItem("isAdmin") === "true";
+  const { data: members } = await supabase
+    .from("members")
+    .select()
+    .eq("group_id", groupId);
+  const list = document.getElementById("member-list");
+  list.innerHTML = "";
+  for (const m of members || []) {
+    const li = document.createElement("li");
+    li.textContent = `${m.name} (${m.points})`;
+    if (isAdmin && m.id !== memberId) {
+      const btn = document.createElement("button");
+      btn.textContent = "Kick";
+      btn.addEventListener("click", () => kickMember(m.id));
+      li.appendChild(btn);
+    }
+    list.appendChild(li);
+  }
+}
+
+async function kickMember(id) {
+  await supabase.from("members").delete().eq("id", id);
+  refreshMembers();
+}
+
+const deleteGroupBtn = document.getElementById("delete-group");
+if (deleteGroupBtn) {
+  deleteGroupBtn.addEventListener("click", async () => {
+    const groupId = localStorage.getItem("groupId");
+    if (confirm("Delete group?")) {
+      await supabase.from("groups").delete().eq("id", groupId);
+      localStorage.clear();
+      window.location.href = "index.html";
+    }
+  });
+}
+
+const updateGroupForm = document.getElementById("update-group-form");
+if (updateGroupForm) {
+  updateGroupForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const groupId = localStorage.getItem("groupId");
+    const name = document.getElementById("group-name-input").value.trim();
+    const { error } = await supabase
+      .from("groups")
+      .update({ name })
+      .eq("id", groupId);
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    document.getElementById("group-name").textContent = name;
+  });
+}
+
+if (createBetForm) {
+  createBetForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const groupId = localStorage.getItem("groupId");
+    const memberId = localStorage.getItem("memberId");
+    if (!groupId || !memberId) {
+      alert("Join a group first");
+      return;
+    }
+    const form = e.target;
+    const description = form.description.value.trim();
+    const optionA = form.optionA.value.trim();
+    const optionB = form.optionB.value.trim();
+    const exclusionsRaw = form.exclusions.value.trim();
+    const { data: bet, error } = await supabase
+      .from("bets")
+      .insert({
+        group_id: groupId,
+        creator_member_id: memberId,
+        description,
+        option_a: optionA,
+        option_b: optionB,
+      })
+      .select()
+      .single();
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    if (exclusionsRaw) {
+      const names = exclusionsRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (names.length) {
+        const { data: members } = await supabase
+          .from("members")
+          .select("id")
+          .eq("group_id", groupId)
+          .in("name", names);
+        for (const m of members || []) {
+          await supabase
+            .from("bet_exclusions")
+            .insert({ bet_id: bet.id, member_id: m.id });
+        }
+      }
+    }
+    form.reset();
+  });
+}
+
+if (document.getElementById("group-info")) {
+  loadGroupPage();
+}

--- a/group.html
+++ b/group.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>FriendBet Group</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>FriendBet Group</h1>
+    <section id="group-info">
+      <h2 id="group-name"></h2>
+      <p>Join Code: <span id="group-code"></span></p>
+      <form id="update-group-form" class="admin-only hidden">
+        <label>
+          Group Name
+          <input type="text" id="group-name-input" />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+      <button id="delete-group" class="admin-only hidden">Delete Group</button>
+    </section>
+
+    <section id="members">
+      <h3>Members</h3>
+      <ul id="member-list"></ul>
+    </section>
+
+    <section id="create-bet">
+      <h3>Create Bet</h3>
+      <form id="create-bet-form">
+        <label>
+          Description
+          <input type="text" name="description" required />
+        </label>
+        <label>
+          Option A
+          <input type="text" name="optionA" required />
+        </label>
+        <label>
+          Option B
+          <input type="text" name="optionB" required />
+        </label>
+        <label>
+          Exclude Members (comma separated)
+          <input type="text" name="exclusions" />
+        </label>
+        <button type="submit">Create Bet</button>
+      </form>
+    </section>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>FriendBet</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>FriendBet</h1>
+
+    <section id="create-group">
+      <h2>Create Group</h2>
+      <form id="create-group-form">
+        <label>
+          Group Name
+          <input type="text" name="groupName" required />
+        </label>
+        <label>
+          Start Points
+          <input type="number" name="startPoints" value="100" />
+        </label>
+        <label>
+          Your Name
+          <input type="text" name="memberName" required />
+        </label>
+        <button type="submit">Create Group</button>
+      </form>
+    </section>
+
+    <section id="join-group">
+      <h2>Join Group</h2>
+      <form id="join-group-form">
+        <label>
+          Join Code
+          <input type="text" name="joinCode" required />
+        </label>
+        <label>
+          Your Name
+          <input type="text" name="memberName" required />
+        </label>
+        <button type="submit">Join Group</button>
+      </form>
+    </section>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,27 @@
+body {
+  background: #111;
+  color: #eee;
+  font-family: sans-serif;
+  margin: 2rem;
+}
+
+label {
+  display: block;
+  margin: 0.5rem 0;
+}
+
+input,
+button {
+  background: #222;
+  color: #eee;
+  border: 1px solid #444;
+  padding: 0.5rem;
+}
+
+button {
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}

--- a/supabase.txt
+++ b/supabase.txt
@@ -1,0 +1,45 @@
+-- Enable UUID extension
+create extension if not exists "uuid-ossp";
+
+create table groups (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  join_code text unique not null default upper(left(replace(uuid_generate_v4()::text, '-', ''), 6)),
+  start_points integer not null default 100,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table members (
+  id uuid primary key default uuid_generate_v4(),
+  group_id uuid references groups(id) on delete cascade,
+  name text not null,
+  points integer not null,
+  is_admin boolean not null default false,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table bets (
+  id uuid primary key default uuid_generate_v4(),
+  group_id uuid references groups(id) on delete cascade,
+  creator_member_id uuid references members(id) on delete set null,
+  description text not null,
+  option_a text not null,
+  option_b text not null,
+  status text not null default 'open',
+  winning_option text,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+create table bet_exclusions (
+  bet_id uuid references bets(id) on delete cascade,
+  member_id uuid references members(id) on delete cascade,
+  primary key (bet_id, member_id)
+);
+
+create table wagers (
+  bet_id uuid references bets(id) on delete cascade,
+  member_id uuid references members(id) on delete cascade,
+  option text not null,
+  amount integer not null,
+  primary key (bet_id, member_id)
+);


### PR DESCRIPTION
## Summary
- Redirect users to group-specific page with admin controls for renaming, deleting, and member management
- Store membership in localStorage and handle group management on client
- Provide Supabase SQL commands with admin flag in separate text file

## Testing
- `npx prettier --check index.html group.html style.css app.js`
- `node --check app.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68be566055848320be2fe3b74a8a5692